### PR TITLE
Center align and uppercase the statusbar time 🕰

### DIFF
--- a/OldOS/OldOS/Common.swift
+++ b/OldOS/OldOS/Common.swift
@@ -572,9 +572,6 @@ struct status_bar_in_app: View {
                     Image(systemName: "wifi").gradientForegroundNonDynamic(colors: [Color.init(red: 32/255, green: 157/255, blue: 237/255), Color.init(red: 72/255, green: 118/255, blue: 196/255)]) .opacity(wifi_connected ? 1 : 0).shadow(color: Color.white.opacity(0.84), radius: 2, x: 0.0, y: 2).mask( Image(systemName: "wifi").gradientForegroundNonDynamic(colors: [Color.init(red: 32/255, green: 157/255, blue: 237/255), Color.init(red: 72/255, green: 118/255, blue: 196/255)]) .opacity(wifi_connected ? 1 : 0).shadow(color: Color.white.opacity(0.84), radius: 2, x: 0.0, y: 2).innerShadow2(color: Color.black.opacity(0.8), radius: 1))//Is it messy, yes, does it work, yes
                 }
                 Spacer()
-                Text(timeString(date: date)).foregroundColor(Color.black).font(.custom("Helvetica Neue Bold", size: 15)).shadow(color: Color.white.opacity(0.84), radius: 2, x: 0.0, y: 2)
-                
-                Spacer()
                 Text("\(Int(battery_level))%").foregroundColor(Color.init(red: 74/255, green: 74/255, blue: 74/255)).font(.custom("Helvetica Neue Bold", size: 15)).shadow(color: Color.white.opacity(0.84), radius: 2, x: 0.0, y: 2).offset(x: 10) //.isHidden(charging)
                 battery_in_app(battery: Float(battery_level/100), charging: charging)
                     .onReceive(timer) { input in
@@ -600,6 +597,11 @@ struct status_bar_in_app: View {
                     }.offset(x: 5)
                 //Spacer()
             }.padding([.leading, .trailing], 4)
+            HStack {
+                Spacer()
+                Text(timeString(date: date).uppercased()).foregroundColor(Color.black).font(.custom("Helvetica Neue Bold", size: 15)).shadow(color: Color.white.opacity(0.84), radius: 2, x: 0.0, y: 2)
+                Spacer()
+            }
         }.onAppear() {
             if carrier_id == "" {
             let networkInfo = CTTelephonyNetworkInfo()
@@ -620,10 +622,8 @@ struct status_bar_in_app: View {
         }
     }
     func timeString(date: Date) -> String {
-        let time = timeFormat.string(from: date)
-        return time
+        timeFormat.string(from: date)
     }
-    
 }
 
 //Yes, all this for a battery

--- a/OldOS/OldOS/HomeScreen.swift
+++ b/OldOS/OldOS/HomeScreen.swift
@@ -555,13 +555,6 @@ struct status_bar: View {
                 }
                 Image(systemName: "wifi").foregroundColor(Color.init(red: 190/255, green: 190/255, blue: 190/255)).opacity(wifi_connected ? 1 : 0)
                 Spacer()
-                if locked {
-                    Image(systemName: "lock.fill").resizable().foregroundColor(Color.init(red: 190/255, green: 190/255, blue: 190/255)).frame(width: 10, height: 14)
-                } else {
-                    Text(timeString(date: date)).foregroundColor(Color.init(red: 190/255, green: 190/255, blue: 190/255)).font(.custom("Helvetica Neue Medium", size: 15))
-                    
-                }
-                Spacer()
                 Text("\(Int(battery_level))%").isHidden(charging).foregroundColor(Color.init(red: 190/255, green: 190/255, blue: 190/255)).font(.custom("Helvetica Neue Medium", size: 15)).offset(x: 10)
                 battery(battery: Float(battery_level/100), charging: charging)
                     .onReceive(timer) { input in
@@ -587,6 +580,15 @@ struct status_bar: View {
                     }.offset(x: 5)
                 //Spacer()
             }.padding([.leading, .trailing], 4)
+            HStack {
+                Spacer()
+                if locked {
+                    Image(systemName: "lock.fill").resizable().foregroundColor(Color.init(red: 190/255, green: 190/255, blue: 190/255)).frame(width: 10, height: 14)
+                } else {
+                    Text(timeString(date: date).uppercased()).foregroundColor(Color.init(red: 190/255, green: 190/255, blue: 190/255)).font(.custom("Helvetica Neue Medium", size: 15))
+                }
+                Spacer()
+            }
         }.onAppear() {
             if carrier_id == "" {
             let networkInfo = CTTelephonyNetworkInfo()
@@ -607,10 +609,8 @@ struct status_bar: View {
         }
     }
     func timeString(date: Date) -> String {
-        let time = timeFormat.string(from: date)
-        return time
+        timeFormat.string(from: date)
     }
-    
 }
 
 struct dock2: View {


### PR DESCRIPTION
The time on the status bar should be center-aligned, and uppercased.

Before | After
--- | ---
![IMG_8101](https://user-images.githubusercontent.com/16542463/121727572-fd3dba00-cae3-11eb-86dd-3ea740a2a795.PNG) | ![IMG_0030](https://user-images.githubusercontent.com/16542463/121727610-075fb880-cae4-11eb-9125-045c9ea56de1.PNG)
![IMG_8102](https://user-images.githubusercontent.com/16542463/121727722-2f4f1c00-cae4-11eb-85a4-fba8bbd851e8.PNG) | ![IMG_0031](https://user-images.githubusercontent.com/16542463/121727736-337b3980-cae4-11eb-8181-78bfbf45a323.PNG)
