### PR TITLE
Spotlight search on home button 🔍

### DIFF
--- a/OldOS/OldOS/HomeScreen.swift
+++ b/OldOS/OldOS/HomeScreen.swift
@@ -111,7 +111,13 @@ struct home_bar: View {
                         }
                     } else {
                     withAnimation() {
-                        selectedPage = 1
+                        // when on the first page, pressing the home button shows the spotlight search
+                        // https://www.youtube.com/watch?v=hMZXnyk2SJA
+                        if selectedPage == 1 {
+                            selectedPage = 0
+                        } else {
+                            selectedPage = 1
+                        }
                     }
                     }
                 }) {


### PR DESCRIPTION
For added realism, pressing the home button when already on the first page of the springboard shows the spotlight search.

https://www.youtube.com/watch?v=hMZXnyk2SJA