### PR TITLE
Set custom user agent to iOS 4

### DIFF
--- a/OldOS/OldOS/Safari.swift
+++ b/OldOS/OldOS/Safari.swift
@@ -657,6 +657,7 @@ struct Webview : UIViewRepresentable {
         webview.scrollView.delegate = context.coordinator
         webview.scrollView.backgroundColor = UIColor(red: 93/255, green: 99/255, blue: 103/255, alpha: 1.0)
         webview.configuration.suppressesIncrementalRendering = true
+        webview.customUserAgent = "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A293 Safari/6531.22.7"webview.customUserAgent = "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A293 Safari/6531.22.7"
         return webview
     }
     


### PR DESCRIPTION
This changes the user agent within Safari to be that of an iPhone 4 on iOS 4. This allows sites like JailbreakMe to load correctly and many sites like Google load differently when they parse this user agent as seen here:
Current:
![IMG_0674](https://user-images.githubusercontent.com/62785552/126512256-03c909c4-4d96-44fa-9203-047925194252.jpeg)
![IMG_0677](https://user-images.githubusercontent.com/62785552/126512300-31453d98-6822-48d5-b6ef-341ced50fe97.jpeg)

With this change: 
![IMG_0675](https://user-images.githubusercontent.com/62785552/126512351-3a1fee49-93aa-4bd5-93ab-97794b8a1042.jpeg)
![IMG_0676](https://user-images.githubusercontent.com/62785552/126512364-f527e7ca-c058-487f-bb72-c42edd895f9f.jpeg)

